### PR TITLE
Clsx regex refinement

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ A regex expressions for tailwind intellisense
 
 ```json
 "tailwindCSS.experimental.classRegex": [
-  ["clsx\\(([^]*)\\)", "(?:'|\"|`)([^\"'`]*)(?:'|\"|`)"]
+  ["clsx\\(.*?\\)(?!\\])", "(?:'|\"|`)([^\"'`]*)(?:'|\"|`)"]
 ]
 
 # Take note of the outer square brackets!


### PR DESCRIPTION
Hey,

Currently, clsx regex matches everything between `clsx(` and `)`, but if there is a comment right after that and `)` is used, the regex considers this a valid pattern, for example:
`clsx() // "ml-" ()`
The above mentioned is valid and tailwind will auto suggest class there.
So I have updated the regex to fix it. ([Regexr test](https://regexr.com/7usdh))

Thanks,