### PR TITLE
Add new TS/JS string/array tailwind regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Credits: [mxmalykhin](https://github.com/mxmalykhin)
 ---
 
 #### TypeScript or JavaScript, string or array with keyword
-Edit Styles keyword to target different variable names/suffixes
+>Edit Styles keyword to target different variable names/suffixes
 ```json
 "tailwindCSS.experimental.classRegex": [
   ["Styles\\s*(?::\\s*[^=]+)?\\s*=\\s*([^;]*);", "['\"`]([^'\"`]*)['\"`]"]
@@ -164,6 +164,7 @@ const variableStyles: (string | undefined)[] = [
 ```js
 const baseStyles = `items-center flex p-5 mx-2 my-1`;
 ```
+Credits: [avgvstvs96](https://github.com/avgvstvs96)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A regex expressions for tailwind intellisense
 - [Plain Javascript Object](#plain-javascript-object)
 - [JavaScript string variable](#javascript-string-variable)
 - [JavaScript string variable with keywords](#javascript-string-variable-with-keywords)
+- [TypeScript or JavaScript variables, strings or arrays with keyword](#typescript-or-javascript-variables-strings-or-arrays-with-keyword)
 - [tailwind-rn](#tailwind-rn)
 - [cva](#cva)
 - [classList](#classlist)
@@ -143,8 +144,15 @@ Credits: [mxmalykhin](https://github.com/mxmalykhin)
 
 ---
 
-#### TypeScript or JavaScript, string or array with keyword
->Edit Styles keyword to target different variable names/suffixes
+#### TypeScript or JavaScript variables, strings or arrays with keyword
+
+Captures Tailwind classes based on the following patterns:
+
+- variables ending with a "Styles" suffix and with or without TS types.
+- classes within single quotes, double quotes, or backticks
+- classes within strings or arrays
+
+> Edit Styles keyword to target different variable names/suffixes
 ```json
 "tailwindCSS.experimental.classRegex": [
   ["Styles\\s*(?::\\s*[^=]+)?\\s*=\\s*([^;]*);", "['\"`]([^'\"`]*)['\"`]"]

--- a/README.md
+++ b/README.md
@@ -143,6 +143,31 @@ Credits: [mxmalykhin](https://github.com/mxmalykhin)
 
 ---
 
+#### TypeScript or JavaScript, string or array with keyword
+Edit Styles keyword to target different variable names/suffixes
+```json
+"tailwindCSS.experimental.classRegex": [
+  ["Styles\\s*(?::\\s*[^=]+)?\\s*=\\s*([^;]*);", "['\"`]([^'\"`]*)['\"`]"]
+]
+```
+
+Examples:
+
+```ts
+const variableStyles: (string | undefined)[] = [
+  className,
+  showCaret ? 'pr-1' : '',
+  icon ? 'px-1.5 py-0.5' : 'px-3 py-1',
+];
+```
+
+```js
+const baseStyles = `items-center flex p-5 mx-2 my-1`;
+```
+
+---
+
+
 #### tailwind-rn
 > [tailwind-rn](https://github.com/vadimdemedes/tailwind-rn)
 ```json


### PR DESCRIPTION
Add another regex option that works for any TS or JS variable with a "Styles" suffix - classes within single quotes, double quotes, or backticks; as strings or arrays; and with or without TS types.

---
#### TypeScript or JavaScript, string or array with keyword
Captures Tailwind classes based on the following patterns:
- variables ending with a "Styles" suffix and with or without TS types.
- classes within single quotes, double quotes, or backticks
- classes within strings or arrays 
>Edit Styles keyword to target different variable names/suffixes
```json
"tailwindCSS.experimental.classRegex": [
  ["Styles\\s*(?::\\s*[^=]+)?\\s*=\\s*([^;]*);", "['\"`]([^'\"`]*)['\"`]"]
]
```

Examples:

```ts
const variableStyles: (string | undefined)[] = [
  className,
  showCaret ? 'pr-1' : '',
  icon ? 'px-1.5 py-0.5' : 'px-3 py-1',
];
```

```js
const baseStyles = `items-center flex p-5 mx-2 my-1`;
```

Credits: [avgvstvs96](https://github.com/avgvstvs96)