### PR TITLE
feat(DOM className): added regex for DOM className

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,21 @@ document.body.classList.remove('bg-red-500');
 
 Credits: [alexvipond](https://gitbub.com/alexvipond)
 
+```json
+"tailwindCSS.experimental.classRegex": [
+  ["\\s*.className\\s*=\\s*['\\\"](.*?)['\\\"]"]
+]
+
+# Take note of the outer square brackets!
+```
+
+```js
+document.body.className = 'bg-red-500';
+yourCustumEl.className = 'bg-red-500';
+```
+
+Credits: [dennisdotg](https://gitbub.com/dennisdotg)
+
 #### Comment Tagging
 ```json
 "tailwindCSS.experimental.classRegex": [


### PR DESCRIPTION
Hello guys,

I noticed that there is no intellicense on for example
```js
document.body.className = "bg-red-500";

const el = document.createElement("div");
el.className = "bg-red-500";
```

![image](https://github.com/user-attachments/assets/4d68cf95-5e55-4b01-962d-4c10a58e66d3)
![image](https://github.com/user-attachments/assets/3d6349ea-f4e2-4e04-a252-3100568e867c)
