### PR TITLE
feat: update cva regex to support Tailwind v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Credits: [tommulkins](https://github.com/tommulkins)
 
 ```json
 "tailwindCSS.experimental.classRegex": [
-  ["cva\\(([^)]*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"]
+  ["cva\\(([^;]*)[\\);]", "[`'\"`]([^'\"`;]*)[`'\"`]"]
 ]
 
 # Take note of the outer square brackets!
@@ -238,7 +238,8 @@ cva("rounded", {
   variants: {
     size: {
       sm: "p-4",
-      md: "p-6"
+      md: "p-6",
+      lg: "p-(lg-padding)" // Supports referencing variables 
     }
   }
 })


### PR DESCRIPTION
Tailwind v4 introduce direct references to variables in classnames with the pattern `classname-(variable-name)`. This commit fixes the cva regex to accept this new format by reusing twMerge regex.